### PR TITLE
Cloudproof 2 2 0 - removal of compact live feature

### DIFF
--- a/.github/workflows/cargo-lint.yml
+++ b/.github/workflows/cargo-lint.yml
@@ -12,13 +12,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
-    services:
-      redis:
-        image: redis:latest
-        ports:
-          - 6379:6379
-        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
-
     steps:
       - name: Dump Github variables
         uses: crazy-max/ghaction-dump-context@v1

--- a/.github/workflows/cargo-lint.yml
+++ b/.github/workflows/cargo-lint.yml
@@ -12,6 +12,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
+    services:
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
       - name: Dump Github variables
         uses: crazy-max/ghaction-dump-context@v1

--- a/.github/workflows/cloudproof.yml
+++ b/.github/workflows/cloudproof.yml
@@ -30,7 +30,7 @@ on:
         type: string
       bench-features:
         required: false
-        default: ''
+        default: ""
         type: string
 
 jobs:
@@ -55,7 +55,7 @@ jobs:
     with:
       toolchain: ${{ inputs.toolchain }}
       target: x86_64-pc-windows-gnu
-      feature: ffi,cloud,compact_live
+      feature: ffi,cloud
       os: ubuntu-20.04
       pre-requisites: |
         sudo apt-get update && sudo apt-get install -y gcc-mingw-w64-x86-64 binutils-mingw-w64-x86-64 zip
@@ -69,7 +69,7 @@ jobs:
     with:
       toolchain: ${{ inputs.toolchain }}
       target: x86_64-apple-darwin
-      feature: ffi,cloud,compact_live
+      feature: ffi,cloud
       os: macos-12
       pre-requisites: |
         rustup target add aarch64-apple-ios x86_64-apple-ios
@@ -108,20 +108,20 @@ jobs:
     with:
       toolchain: ${{ inputs.toolchain }}
       target: x86_64-unknown-linux-gnu
-      feature: ffi,cloud,compact_live
+      feature: ffi,cloud
       os: ubuntu-20.04
       pre-requisites: |
         sudo apt update
         sudo apt install -y gnuplot
         cat /proc/cpuinfo
-      artifacts: ''
+      artifacts: ""
 
   linux-centos7:
     uses: ./.github/workflows/cargo_in_docker.yml
     with:
       toolchain: ${{ inputs.toolchain }}
       target: x86_64-unknown-linux-gnu
-      feature: ffi,cloud,compact_live
+      feature: ffi,cloud
       os: ubuntu-20.04
       pre-requisites: |
         cargo install --locked cbindgen || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6] - 2023-06-05
+
+### Features
+
+- Removed live compact feature for cloudproof_findex
+
 ## [0.5] - 2023-06-05
 
 ### Bug Fixes


### PR DESCRIPTION
Removed the `compact live` feature which is no more supported in Findex 5.0.0 and is used in cloudprooff 2.2.0