### PR TITLE
feat(ci): add reusable workflow for Azure Trusted Signing

### DIFF
--- a/.github/workflows/sign-windows-artifacts.yml
+++ b/.github/workflows/sign-windows-artifacts.yml
@@ -5,9 +5,15 @@ on:
   workflow_call:
     inputs:
       files-folder:
-        description: Path to the folder containing files to sign (relative to workspace root)
-        required: true
+        description: Path to the folder containing files to sign. Required unless file-list is provided.
+        required: false
         type: string
+        default: ""
+      file-list:
+        description: Path to a text file listing files to sign (one path per line). Takes precedence over files-folder when provided.
+        required: false
+        type: string
+        default: ""
       files-folder-filter:
         description: Comma-separated list of file extensions to sign
         required: false
@@ -56,7 +62,23 @@ jobs:
           name: ${{ inputs.artifact-to-download }}
           path: ${{ inputs.files-folder }}
 
-      - name: Sign files
+      - name: Sign files (file-list mode)
+        if: inputs.file-list != ''
+        uses: azure/artifact-signing-action@v2
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ inputs.endpoint }}
+          signing-account-name: ${{ inputs.signing-account-name }}
+          certificate-profile-name: ${{ inputs.certificate-profile-name }}
+          file-list: ${{ inputs.file-list }}
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Sign files (folder mode)
+        if: inputs.file-list == ''
         uses: azure/artifact-signing-action@v2
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/sign-windows-artifacts.yml
+++ b/.github/workflows/sign-windows-artifacts.yml
@@ -1,0 +1,80 @@
+---
+name: Sign Windows Artifacts (Azure Trusted Signing)
+
+on:
+  workflow_call:
+    inputs:
+      files-folder:
+        description: Path to the folder containing files to sign (relative to workspace root)
+        required: true
+        type: string
+      files-folder-filter:
+        description: Comma-separated list of file extensions to sign
+        required: false
+        type: string
+        default: exe
+      artifact-to-download:
+        description: Name of a GHA artifact to download into files-folder before signing (leave empty to skip)
+        required: false
+        type: string
+        default: ""
+      artifact-name:
+        description: Name for the uploaded signed artifact (leave empty to skip upload)
+        required: false
+        type: string
+        default: ""
+      endpoint:
+        description: Azure Trusted Signing endpoint URL
+        required: false
+        type: string
+        default: https://weu.codesigning.azure.net/
+      signing-account-name:
+        description: Azure Trusted Signing account name
+        required: true
+        type: string
+      certificate-profile-name:
+        description: Azure Trusted Signing certificate profile name
+        required: true
+        type: string
+    secrets:
+      AZURE_TENANT_ID:
+        required: true
+      AZURE_CLIENT_ID:
+        required: true
+      AZURE_CLIENT_SECRET:
+        required: true
+
+jobs:
+  sign:
+    name: Sign with Azure Trusted Signing
+    runs-on: windows-latest
+    steps:
+      - name: Download artifact to sign
+        if: inputs.artifact-to-download != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-to-download }}
+          path: ${{ inputs.files-folder }}
+
+      - name: Sign files
+        uses: azure/artifact-signing-action@v2
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ inputs.endpoint }}
+          signing-account-name: ${{ inputs.signing-account-name }}
+          certificate-profile-name: ${{ inputs.certificate-profile-name }}
+          files-folder: ${{ inputs.files-folder }}
+          files-folder-filter: ${{ inputs.files-folder-filter }}
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Upload signed artifacts
+        if: inputs.artifact-name != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.files-folder }}
+          if-no-files-found: error

--- a/.github/workflows/test-sign.yml
+++ b/.github/workflows/test-sign.yml
@@ -1,0 +1,40 @@
+---
+name: Test - Azure Trusted Signing
+
+on:
+  workflow_dispatch:
+
+jobs:
+  prepare:
+    name: Build test binary
+    runs-on: windows-latest
+    steps:
+      - name: Create dummy EXE for signing
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path to-sign
+          # Copy a real PE binary so Azure Trusted Signing accepts it
+          Copy-Item "C:\Windows\System32\cmd.exe" "to-sign\test.exe"
+          Write-Host "Prepared to-sign\test.exe"
+
+      - name: Upload test binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-binary
+          path: to-sign/
+          if-no-files-found: error
+
+  sign:
+    needs: prepare
+    uses: ./.github/workflows/sign-windows-artifacts.yml
+    with:
+      artifact-to-download: test-binary
+      files-folder: to-sign
+      files-folder-filter: exe
+      signing-account-name: cosmian-codesigning-test
+      certificate-profile-name: cosmian-test-profile
+      artifact-name: test-signed
+    secrets:
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID_POC }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_POC }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET_POC }}


### PR DESCRIPTION
## Summary

Reusable workflow for signing Windows artifacts via Azure Trusted Signing (`azure/artifact-signing-action@v2`).

Based on the signing POC: https://github.com/p0wline/cosmian-signing-poc

## Files

- `sign-windows-artifacts.yml` — the reusable workflow (`workflow_call`)
- `test-sign.yml` — test caller (`workflow_dispatch`) for manual testing

## Usage

```yaml
jobs:
  sign:
    uses: Cosmian/reusable_workflows/.github/workflows/sign-windows-artifacts.yml@develop
    with:
      files-folder: target/release
      files-folder-filter: exe
      signing-account-name: cosmian-codesigning-test
      certificate-profile-name: cosmian-test-profile
      artifact-to-download: my-build-artifact   # optional
      artifact-name: signed-installers           # optional
    secrets:
      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID_POC }}
      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_POC }}
      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET_POC }}
```

## Testing

Actions → "Test - Azure Trusted Signing" → Run workflow (on this branch).
Requires secrets `AZURE_TENANT_ID_POC`, `AZURE_CLIENT_ID_POC`, `AZURE_CLIENT_SECRET_POC` set in repo settings.

## Note

Azure Trusted Signing uses OV cert. SmartScreen warns on first download until certificate builds reputation. EV cert needed for immediate bypass.